### PR TITLE
I moved the h-card inside of h-entry

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,8 +6,7 @@
   <section class="e-content post-body">
       {{ .Content }}
   </section>
-</article>
-<section id="post-meta" class="clearfix">
+  <section id="post-meta" class="clearfix">
   <a href="/">
     <img class="u-photo avatar" src="{{ .Site.Author.avatar }}" width="96" height="96">
     <div>
@@ -16,4 +15,6 @@
     </div>
   </a>
 </section>
+</article>
+
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,8 @@
 
 <section id="wrapper">
   <ul>
-    <li><a href="/feed.xml">RSS</a></li>
-    <li><a href="/feed.json">JSON Feed</a></li>
+    <li><a href="/feed.xml" rel="alternate">RSS</a></li>
+    <li><a href="/feed.json" rel="alternate">JSON Feed</a></li>
     <li><a href="https://micro.blog/{{ .Site.Author.username }}" rel="me">Micro.blog</a></li>
 <!--     <li><a class="u-email" href="mailto:" rel="me">Email</a></li> -->
   </ul>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,7 +3,6 @@
   <header>
 	{{ with .Title }}
     <h1 class="p-name">{{ . }}</h1>
-<a class="u-author" href="/"></a> 
     {{ end }}
     <h2 class="headline">
       <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,6 +3,7 @@
   <header>
 	{{ with .Title }}
     <h1 class="p-name">{{ . }}</h1>
+<a class="u-author" href="/"></a> 
     {{ end }}
     <h2 class="headline">
       <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">


### PR DESCRIPTION
You have two choices with this theme:
*in this PR I moved the section with the h-card inside of the h-entry
* The other option (Revert to d2facf6) is to us <a class="u-author href="/"></a>

I could not discover how imgs are used in this theme but do no that img posts are missing u-photo and imgs in article posts correctly do not get them. 