### PR TITLE
Adds a title to the individual category page.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,3 +1,10 @@
 {{ define "main" }}
+  {{ if ne .IsHome true }}
+  <section id="wrapper">
+    <header>
+      <h1>{{- if .Title }}{{ .Title }}{{- end -}}</h1>
+    </header>
+  </section>
+  {{ end }}
   {{ partial "post-list.html" . }}
 {{ end }}


### PR DESCRIPTION
Currently the theme does not display any category title at the top of the individual category pages. Changes have been made to the layouts/_default/list.html to check if it is not homepage, then add the category title to the individual category list pages.