### PR TITLE
Fix list style in post list

### DIFF
--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -318,11 +318,11 @@ Post List
 =========================================== */
 
 
-#post-list li {
+#post-list > li {
 	list-style-type: none;
 }
 
-#post-list li:last-child {
+#post-list > li:last-child {
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
Setting a list style of "none" for all list items within the #post-list
is overly broad. We should only affect the direct child list items so
that any <li> tags within a post retain their proper list style.