### PR TITLE
Add padding around post image

### DIFF
--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -194,6 +194,10 @@ article ul li {
 	list-style-type: disc !important;
 }
 
+article img {
+  padding: 20px 0px 20px 0px;	
+}
+
 b, strong {
 	font-weight: 500;
   color: #1E2025;
@@ -423,7 +427,8 @@ footer #wrapper {
   float: left;
   margin-right: 15px;
   box-shadow: 0 0 0 3px #fff, 0 0 0 4px #eee;
-	border-radius: 50%;
+  border-radius: 50%;
+  padding: 0px;
 }
 
 /* Others */


### PR DESCRIPTION
Currently there's no space between images and text in articles. This PR adds a padding around images in `particle's, except the avatar (which's also lives inside `article`)

<img width="895" alt="Screen Shot 2022-02-16 at 14 00 00" src="https://user-images.githubusercontent.com/139272/154270027-8e23a116-c50f-4eb6-b86e-f718c89c8c35.png">