### PR TITLE
Fixed duplicate footer ID, CSS

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <footer id="footer">
 
-<section id="wrapper">
+<section>
   <ul>
     <li><a href="/feed.xml">RSS</a></li>
     <li><a href="/feed.json">JSON Feed</a></li>

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"title": "Marfa theme",
 	"description": "Micro.blog's Marfa theme."
 }

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -337,7 +337,7 @@ Post List
 
 /* Footer */
 
-footer #wrapper {
+footer section {
 	margin: 0 auto;
 	text-align: center;
 	padding: 35px 0 80px 0;


### PR DESCRIPTION
Don't allow `#wrapper` to be used in more than one place.