### PR TITLE
Support for Hugo 0.158

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
 {{ partial "head.html" . }}
 <body>
   {{ partial "header.html" . }}
-  <section id="wrapper" {{ if eq .File.Dir "about/" }} class="bio" {{ end }}>
+  <section id="wrapper">
 	{{ block "main" . }}{{ end }}
   </section>
   {{ partial "footer.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,10 +9,10 @@
 </article>
 <section id="post-meta" class="clearfix">
   <a href="/">
-    <img class="u-photo avatar" src="{{ .Site.Author.avatar }}" width="96" height="96">
+    <img class="u-photo avatar" src="{{ .Site.Params.author.avatar }}" width="96" height="96">
     <div>
-      <span class="p-author h-card dark">{{ .Site.Author.name }}</span>
-      <span><a href="https://micro.blog/{{ .Site.Author.username }}">@{{ .Site.Author.username }}</a></span>
+      <span class="p-author h-card dark">{{ .Site.Params.author.name }}</span>
+      <span><a href="https://micro.blog/{{ .Site.Params.author.username }}">@{{ .Site.Params.author.username }}</a></span>
     </div>
   </a>
 </section>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
   <ul>
     <li><a href="/feed.xml">RSS</a></li>
     <li><a href="/feed.json">JSON Feed</a></li>
-    <li><a href="https://micro.blog/{{ .Site.Author.username }}" rel="me">Micro.blog</a></li>
+    <li><a href="https://micro.blog/{{ .Site.Params.author.username }}" rel="me">Micro.blog</a></li>
 <!--     <li><a class="u-email" href="mailto:" rel="me">Email</a></li> -->
   </ul>
   <form method="get" id="search" action="https://duckduckgo.com/">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta content="{{ .Site.Author.name }}" name="author">
+  <meta content="{{ .Site.Params.author.name }}" name="author">
 
   <title>
       {{- block "title" . -}}

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -11,5 +11,5 @@
 		{{ end }}
 	{{ end }}
 
-  <a class="cta" href="https://micro.blog/{{ .Site.Author.username }}" rel="me">Also on Micro.blog</a>
+  <a class="cta" href="https://micro.blog/{{ .Site.Params.author.username }}" rel="me">Also on Micro.blog</a>
 </nav>

--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -2,9 +2,9 @@
   <section id="wrapper">
     <header class="h-card">
       <a class="u-url" href="/about/">
-        <img id="avatar" class="u-photo" src="{{ .Site.Author.avatar }}" width="96" height="96" />
+        <img id="avatar" class="u-photo" src="{{ .Site.Params.author.avatar }}" width="96" height="96" />
       </a>
-      <h1 class="p-name" rel="me">{{ .Site.Author.name }}</h1>
+      <h1 class="p-name" rel="me">{{ .Site.Params.author.name }}</h1>
       <h4 class="p-role">{{ .Site.Params.description | safeHTML }}</h4>
     </header>
   </section>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -30,10 +30,10 @@
 		  <span><a href="https://micro.blog/{{ .Params.author.username }}">@{{ .Params.author.username }}</a></span>
 		</div>
   	{{ else }}
-		<img class="u-photo avatar" src="{{ .Site.Author.avatar }}" width="96" height="96">
+		<img class="u-photo avatar" src="{{ .Site.Params.author.avatar }}" width="96" height="96">
 		<div>
-		  <span class="p-name dark">{{ .Site.Author.name }}</span>
-		  <span><a href="https://micro.blog/{{ .Site.Author.username }}">@{{ .Site.Author.username }}</a></span>
+		  <span class="p-name dark">{{ .Site.Params.author.name }}</span>
+		  <span><a href="https://micro.blog/{{ .Site.Params.author.username }}">@{{ .Site.Params.author.username }}</a></span>
 		</div>
 	{{ end }}
     </a>

--- a/layouts/reply/single.html
+++ b/layouts/reply/single.html
@@ -24,10 +24,10 @@
 </article>
 <section id="post-meta" class="clearfix">
   <a href="/">
-    <img class="u-photo avatar" src="{{ .Site.Author.avatar }}" width="96" height="96">
+    <img class="u-photo avatar" src="{{ .Site.Params.author.avatar }}" width="96" height="96">
     <div>
-      <span class="p-author h-card dark">{{ .Site.Author.name }}</span>
-      <span><a href="https://micro.blog/{{ .Site.Author.username }}">@{{ .Site.Author.username }}</a></span>
+      <span class="p-author h-card dark">{{ .Site.Params.author.name }}</span>
+      <span><a href="https://micro.blog/{{ .Site.Params.author.username }}">@{{ .Site.Params.author.username }}</a></span>
     </div>
   </a>
 </section>

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -50,14 +50,6 @@ body {
 	font-weight: 400;
 }
 
-.bio p:first-child {
-	margin-top: 0;
-}
-
-.bio li {
-	list-style-position: outside;
-}
-
 /* Nav */
 
 nav.main-nav {


### PR DESCRIPTION
When running this theme on Hugo 0.158, `{{ if eq .File.Dir "about/" }}` blows up whenever `.File` is `nil`. In earlier versions of Hugo, this issue was silently ignored.

After looking into it, I realized the code was intended to determine whether to add a `bio` class to a wrapper `section` element. However, the logic never actually triggers, so the class was never used. To make the theme compatible with Hugo 0.158, I removed both the logic and the unused class along with its related styles.

I also replaced every instance of `.Site.Author` with `.Site.Params.author`. For more details about that, see https://github.com/microdotblog/theme-blank/pull/12.

These changes have been tested both locally on my machine and in the production environment running Hugo versions 0.91 and 0.158.